### PR TITLE
fix: slug the branch name

### DIFF
--- a/app/Actions/GenerateDomainName.php
+++ b/app/Actions/GenerateDomainName.php
@@ -43,6 +43,6 @@ class GenerateDomainName
             return Str::slug(current($new));
         }
 
-        return $branch;
+        return Str::slug($branch);
     }
 }


### PR DESCRIPTION
In GenerateDomainName, a branch with a / or other non-alpha characters means the domain name would have those characters in it.  A domain name with / in it is not valid.