### PR TITLE
Feat: configurable timeout for forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Veyoze utilizes environment keys similar to a Laravel application, offering flex
 This key holds your Forge API token, enabling Veyoze to communicate with Laravel Forge for site creation and resource management. **Always store this value as an encrypted secret; avoid pasting it directly into your workflow file.**
 
 #### `FORGE_SERVER` (required)
-Specify the server where Veyoze should create and deploy a site.
+Specify the server where Veyoze should create and deploy a site.  The value to use here is the Forge "Server ID" for the target server.  Examples: 723019, 68342, etc.
 
 #### `FORGE_GIT_REPOSITORY` (required)
 Indicate the Git repository name, such as 'mehrancodes/veyoze'.

--- a/README.md
+++ b/README.md
@@ -195,6 +195,9 @@ A flag to pause the provisioning process until the SSL setup completes. By defau
 #### `FORGE_WAIT_ON_DEPLOY`
 This flag pauses the provisioning process until the site deployment completes. By default, it's true, ensuring a smooth and complete deployment before any subsequent steps.
 
+#### `FORGE_TIMEOUT_SECONDS`
+This flag indicates how much time should be allowed for the deployment process.  Defaults to 180 seconds.
+
 ---
 
 ## Features

--- a/app/Services/Forge/ForgeService.php
+++ b/app/Services/Forge/ForgeService.php
@@ -61,6 +61,8 @@ class ForgeService
         $this->setting = new ForgeSetting();
 
         $this->forge = new Forge($this->setting->token);
+
+        $this->forge->setTimeout($this->setting->timeoutSeconds);
     }
 
     public function setServer(Server $server): void

--- a/app/Services/Forge/ForgeSetting.php
+++ b/app/Services/Forge/ForgeSetting.php
@@ -129,6 +129,8 @@ class ForgeSetting
      */
     public bool $waitOnSsl;
 
+    public int $timeoutSeconds;
+
     /**
      * The validation rules.
      */
@@ -152,6 +154,7 @@ class ForgeSetting
         'ssl_required' => ['boolean'],
         'wait_on_ssl' => ['boolean'],
         'wait_on_deploy' => ['boolean'],
+        'timeout_seconds' => ['int', 'nullable'],
     ];
 
     public function __construct()

--- a/config/forge.php
+++ b/config/forge.php
@@ -64,4 +64,6 @@ return [
     // Flag to pause until site deployment completes during provisioning (default: true).
     'wait_on_deploy' => env('FORGE_WAIT_ON_DEPLOY', true),
 
+    'timeout_seconds' => env('FORGE_TIMEOUT_SECONDS', 180),
+
 ];


### PR DESCRIPTION
Forge deployments were taking more than the default 30 seconds.  Added configurable parameter, defaulting to 180 seconds (3 minutes).