### PR TITLE
fix: get last match from preg_match for domain/branch naming

### DIFF
--- a/app/Actions/GenerateDomainName.php
+++ b/app/Actions/GenerateDomainName.php
@@ -38,9 +38,8 @@ class GenerateDomainName
         $pattern = $this->service->setting->subdomainPattern;
 
         if (isset($pattern)) {
-            preg_match($pattern, $branch, $new);
-
-            return Str::slug(current($new));
+            preg_match($pattern, $branch, $matches);
+            $branch = array_pop($matches);
         }
 
         return Str::slug($branch);

--- a/app/Actions/GenerateDomainName.php
+++ b/app/Actions/GenerateDomainName.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
-use App\Services\Forge\ForgeService;
 use Illuminate\Support\Str;
 use Lorisleiva\Actions\Concerns\AsAction;
 
@@ -21,27 +20,20 @@ class GenerateDomainName
 {
     use AsAction;
 
-    public function __construct(public ForgeService $service)
+    public function handle(string $domain, string $branch, ?string $pattern): string
     {
-    }
-
-    public function handle(): string
-    {
-        return str($this->formatBranchName())
-            ->append('.', $this->service->setting->domain)
+        return str($this->formatBranchName($branch, $pattern))
+            ->append('.', $domain)
             ->toString();
     }
 
-    private function formatBranchName(): string
+    private function formatBranchName(string $branch, ?string $pattern): string
     {
-        $branch = $this->service->setting->branch;
-        $pattern = $this->service->setting->subdomainPattern;
-
         if (isset($pattern)) {
             preg_match($pattern, $branch, $matches);
             $branch = array_pop($matches);
         }
 
-        return Str::slug($branch);
+        return Str::slug($branch, '-', 'en', ['+' => '-', '_' => '-', '@' => '-']);
     }
 }

--- a/app/Services/Forge/ForgeService.php
+++ b/app/Services/Forge/ForgeService.php
@@ -69,7 +69,11 @@ class ForgeService
     public function getFormattedDomainName(): ?string
     {
         if (is_null($this->formattedDomain)) {
-            $this->formattedDomain = GenerateDomainName::run();
+            $this->formattedDomain = GenerateDomainName::run(
+                $this->setting->domain,
+                $this->setting->branch,
+                $this->setting->subdomainPattern,
+            );
         }
 
         return $this->formattedDomain;

--- a/tests/Feature/Actions/GenerateDomainNameTest.php
+++ b/tests/Feature/Actions/GenerateDomainNameTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use App\Actions\GenerateDomainName;
+
+it('verify correct domain generation for various branch formats', function ($actual, $expected) {
+    expect(
+        GenerateDomainName::run(
+            $actual['domain'],
+            $actual['branch'],
+            $actual['pattern'],
+        )
+    )
+        ->toBe($expected);
+})
+    ->with([
+        [
+            'actual' => [
+                'branch' => 'user_notification+test',
+                'pattern' => null,
+                'domain' => 'veyoze.com',
+            ],
+            'expected' => 'user-notification-test.veyoze.com',
+        ],
+        [
+            'actual' => [
+                'branch' => 'feature/add-user-notification',
+                'pattern' => '/feature\/(.*)/i',
+                'domain' => 'veyoze.com',
+            ],
+            'expected' => 'add-user-notification.veyoze.com',
+        ],
+        [
+            'actual' => [
+                'branch' => 'feature/add-user-notification',
+                'pattern' => '/feature\/(.*)/i',
+                'domain' => 'sub.veyoze.com',
+            ],
+            'expected' => 'add-user-notification.sub.veyoze.com',
+        ],
+        [
+            'actual' => [
+                'branch' => 'feature/add@user-notification',
+                'pattern' => '/feature\/(.*)/i',
+                'domain' => 'veyoze.com',
+            ],
+            'expected' => 'add-user-notification.veyoze.com',
+        ],
+        [
+            'actual' => [
+                'branch' => 'feature/User-Notification',
+                'pattern' => '/feature\/(.*)/i',
+                'domain' => 'veyoze.com',
+            ],
+            'expected' => 'user-notification.veyoze.com',
+        ],
+        [
+            'actual' => [
+                'branch' => '360-add-user-notification',
+                'pattern' => '/\d+/i',
+                'domain' => 'veyoze.com',
+            ],
+            'expected' => '360.veyoze.com',
+        ],
+        [
+            'actual' => [
+                'branch' => 'vyz-145-add-user-notification',
+                'pattern' => '/vyz-\d+/i',
+                'domain' => 'veyoze.com',
+            ],
+            'expected' => 'vyz-145.veyoze.com',
+        ],
+        [
+            'actual' => [
+                'branch' => 'feature/user@notification!',
+                'pattern' => '/feature\/(.*)/i',
+                'domain' => 'veyoze.com',
+            ],
+            'expected' => 'user-notification.veyoze.com',
+        ],
+    ]);
+
+it('ensure graceful handling of invalid or problematic branch formats', function ($actual, $expected) {
+    expect(
+        GenerateDomainName::run(
+            $actual['domain'],
+            $actual['branch'],
+            $actual['pattern'],
+        )
+    )
+        ->toBe($expected);
+})
+    ->with([
+        [
+            'actual' => [
+                'branch' => 'feature/user-notification',
+                'pattern' => '/feature\/(.*)/i',
+                'domain' => 'veyoze',
+            ],
+            'expected' => 'user-notification.veyoze',
+        ],
+    ]);


### PR DESCRIPTION
Consider

$branch = "feature/foo-bar-abz";
$pattern = "/feature\/(.*)/";

if (isset($pattern)) {
    preg_match($pattern, $branch, $matches);
}

$matches contains

Array
(
    [0] => feature/foo-bar-abz
    [1] => foo-bar-abz
)

The last match seems to be generally what we’d want.

Tried to write a test for this, but the test/setup work seems a bit more complicated than I expected.