### PR TITLE
fix: treat username, database name and domain name the same

### DIFF
--- a/app/Actions/FormatBranchName.php
+++ b/app/Actions/FormatBranchName.php
@@ -13,16 +13,20 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use Illuminate\Support\Str;
 use Lorisleiva\Actions\Concerns\AsAction;
 
-class GenerateDomainName
+class FormatBranchName
 {
     use AsAction;
 
-    public function handle(string $domain, string $branch): string
+    public function handle(string $branch, ?string $pattern): string
     {
-        return str($branch)
-            ->append('.', $domain)
-            ->toString();
+        if (isset($pattern)) {
+            preg_match($pattern, $branch, $matches);
+            $branch = array_pop($matches);
+        }
+
+        return Str::slug($branch, '-', 'en', ['+' => '-', '_' => '-', '@' => '-']);
     }
 }

--- a/app/Actions/FormattedBranchName.php
+++ b/app/Actions/FormattedBranchName.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Veyoze CLI.
+ *
+ * (c) Mehran Rasulian <mehran.rasulian@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace App\Actions;
+
+use Illuminate\Support\Str;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class FormattedBranchName
+{
+    use AsAction;
+
+    protected const STRING_LIMIT = 64;
+    protected const SLUGIFY_DICTIONARY = ['+' => '-', '_' => '-', '@' => '-'];
+
+    public function handle(string $branch, ?string $pattern): string
+    {
+        if (isset($pattern)) {
+            preg_match($pattern, $branch, $matches);
+            $branch = array_pop($matches);
+        }
+
+        $slugged = $this->slugifyIt($branch);
+
+        return Str::limit(
+            $slugged,
+            self::STRING_LIMIT
+        );
+    }
+
+    protected function slugifyIt(string $branch): string
+    {
+        return Str::slug($branch, '-', 'en', self::SLUGIFY_DICTIONARY);
+    }
+}

--- a/app/Actions/FormattedBranchName.php
+++ b/app/Actions/FormattedBranchName.php
@@ -21,6 +21,7 @@ class FormattedBranchName
     use AsAction;
 
     protected const STRING_LIMIT = 64;
+
     protected const SLUGIFY_DICTIONARY = ['+' => '-', '_' => '-', '@' => '-'];
 
     public function handle(string $branch, ?string $pattern): string

--- a/app/Actions/GenerateStandardizedBranchName.php
+++ b/app/Actions/GenerateStandardizedBranchName.php
@@ -16,17 +16,18 @@ namespace App\Actions;
 use Illuminate\Support\Str;
 use Lorisleiva\Actions\Concerns\AsAction;
 
-class FormatBranchName
+class GenerateStandardizedBranchName
 {
     use AsAction;
 
-    public function handle(string $branch, ?string $pattern): string
+    public function handle(string $branch): string
     {
-        if (isset($pattern)) {
-            preg_match($pattern, $branch, $matches);
-            $branch = array_pop($matches);
-        }
+        $firstDigitsOfStringRemoved = preg_replace(
+            '/^\d+-?/',
+            '',
+            $branch
+        );
 
-        return Str::slug($branch, '-', 'en', ['+' => '-', '_' => '-', '@' => '-']);
+        return Str::replace('-', '_', $firstDigitsOfStringRemoved);
     }
 }

--- a/app/Services/Forge/ForgeService.php
+++ b/app/Services/Forge/ForgeService.php
@@ -108,9 +108,11 @@ class ForgeService
 
     public function generateDatabaseName(): string
     {
-        return Str::limit(
-            Str::slug($this->setting->branch, '_'),
-            64
-        );
+        $this->getFormattedDomainName();
+    }
+
+    public function generateUserName(): string
+    {
+        $this->getFormattedDomainName();
     }
 }

--- a/app/Services/Forge/Pipeline/CreateDatabase.php
+++ b/app/Services/Forge/Pipeline/CreateDatabase.php
@@ -24,7 +24,7 @@ class CreateDatabase
 
     public function __invoke(ForgeService $service, Closure $next)
     {
-        if (!$service->setting->dbCreationRequired || !$service->siteNewlyMade) {
+        if (! $service->setting->dbCreationRequired || ! $service->siteNewlyMade) {
             return $next($service);
         }
 

--- a/app/Services/Forge/Pipeline/CreateDatabase.php
+++ b/app/Services/Forge/Pipeline/CreateDatabase.php
@@ -29,7 +29,7 @@ class CreateDatabase
         }
 
         $dbPassword = Str::random(16);
-        $dbName = $service->generateDatabaseName();
+        $dbName = $service->getStandardizedBranchName();
 
         if (! $this->databaseExists($service, $dbName)) {
             $this->information('Creating database.');

--- a/app/Services/Forge/Pipeline/OrCreateNewSite.php
+++ b/app/Services/Forge/Pipeline/OrCreateNewSite.php
@@ -55,7 +55,7 @@ class OrCreateNewSite
             $this->information('---> Enabling site isolation.');
 
             $data['isolated'] = true;
-            $data['username'] = $service->generateUserName();
+            $data['username'] = $service->generateIsolationUsername();
         }
 
         return $data;

--- a/app/Services/Forge/Pipeline/OrCreateNewSite.php
+++ b/app/Services/Forge/Pipeline/OrCreateNewSite.php
@@ -55,7 +55,7 @@ class OrCreateNewSite
             $this->information('---> Enabling site isolation.');
 
             $data['isolated'] = true;
-            $data['username'] = Str::slug($service->setting->branch);
+            $data['username'] = $service->generateUserName();
         }
 
         return $data;

--- a/app/Services/Forge/Pipeline/OrCreateNewSite.php
+++ b/app/Services/Forge/Pipeline/OrCreateNewSite.php
@@ -54,7 +54,7 @@ class OrCreateNewSite
             $this->information('---> Enabling site isolation.');
 
             $data['isolated'] = true;
-            $data['username'] = $service->generateIsolationUsername();
+            $data['username'] = $service->getStandardizedBranchName();
         }
 
         return $data;

--- a/app/Services/Forge/Pipeline/OrCreateNewSite.php
+++ b/app/Services/Forge/Pipeline/OrCreateNewSite.php
@@ -16,7 +16,6 @@ namespace App\Services\Forge\Pipeline;
 use App\Services\Forge\ForgeService;
 use App\Traits\Outputifier;
 use Closure;
-use Illuminate\Support\Str;
 
 class OrCreateNewSite
 {

--- a/app/Services/Forge/Pipeline/RemoveDatabaseUser.php
+++ b/app/Services/Forge/Pipeline/RemoveDatabaseUser.php
@@ -24,7 +24,7 @@ class RemoveDatabaseUser
     public function __invoke(ForgeService $service, Closure $next)
     {
         foreach ($service->forge->databaseUsers($service->setting->server) as $databaseUser) {
-            if ($databaseUser->name === $service->generateDatabaseName()) {
+            if ($databaseUser->name === $service->getStandardizedBranchName()) {
                 $this->information('Removing database with user.');
 
                 foreach ($databaseUser->databases as $database) {

--- a/tests/Feature/Actions/FormatBranchNameTest.php
+++ b/tests/Feature/Actions/FormatBranchNameTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use App\Actions\FormatBranchName;
+
+it('verify correct domain generation for various branch formats', function ($actual, $expected) {
+    expect(
+        FormatBranchName::run(
+            $actual['branch'],
+            $actual['pattern'],
+        )
+    )
+        ->toBe($expected);
+})
+    ->with([
+        [
+            'actual' => [
+                'branch' => 'user_notification+test',
+                'pattern' => null,
+            ],
+            'expected' => 'user-notification-test',
+        ],
+        [
+            'actual' => [
+                'branch' => 'feature/add-user-notification',
+                'pattern' => '/feature\/(.*)/i',
+            ],
+            'expected' => 'add-user-notification',
+        ],
+        [
+            'actual' => [
+                'branch' => 'feature/add-user-notification',
+                'pattern' => '/feature\/(.*)/i',
+            ],
+            'expected' => 'add-user-notification',
+        ],
+        [
+            'actual' => [
+                'branch' => 'feature/add@user-notification',
+                'pattern' => '/feature\/(.*)/i',
+            ],
+            'expected' => 'add-user-notification',
+        ],
+        [
+            'actual' => [
+                'branch' => 'feature/User-Notification',
+                'pattern' => '/feature\/(.*)/i',
+            ],
+            'expected' => 'user-notification',
+        ],
+        [
+            'actual' => [
+                'branch' => '360-add-user-notification',
+                'pattern' => '/\d+/i',
+            ],
+            'expected' => '360',
+        ],
+        [
+            'actual' => [
+                'branch' => 'vyz-145-add-user-notification',
+                'pattern' => '/vyz-\d+/i',
+            ],
+            'expected' => 'vyz-145',
+        ],
+        [
+            'actual' => [
+                'branch' => 'feature/user@notification!',
+                'pattern' => '/feature\/(.*)/i',
+            ],
+            'expected' => 'user-notification',
+        ],
+    ]);
+
+it('ensure graceful handling of invalid or problematic branch formats', function ($actual, $expected) {
+    expect(
+        FormatBranchName::run(
+            $actual['branch'],
+            $actual['pattern'],
+        )
+    )
+        ->toBe($expected);
+})
+    ->with([
+        [
+            'actual' => [
+                'branch' => 'feature/user-notification',
+                'pattern' => '/feature\/(.*)/i',
+            ],
+            'expected' => 'user-notification',
+        ],
+    ]);

--- a/tests/Feature/Actions/FormattedBranchNameTest.php
+++ b/tests/Feature/Actions/FormattedBranchNameTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use App\Actions\FormatBranchName;
+use App\Actions\FormattedBranchName;
 
 it('verify correct domain generation for various branch formats', function ($actual, $expected) {
     expect(
-        FormatBranchName::run(
+        FormattedBranchName::run(
             $actual['branch'],
             $actual['pattern'],
         )
@@ -72,7 +72,7 @@ it('verify correct domain generation for various branch formats', function ($act
 
 it('ensure graceful handling of invalid or problematic branch formats', function ($actual, $expected) {
     expect(
-        FormatBranchName::run(
+        FormattedBranchName::run(
             $actual['branch'],
             $actual['pattern'],
         )

--- a/tests/Feature/Actions/GenerateDomainNameTest.php
+++ b/tests/Feature/Actions/GenerateDomainNameTest.php
@@ -7,7 +7,6 @@ it('verify correct domain generation for various branch formats', function ($act
         GenerateDomainName::run(
             $actual['domain'],
             $actual['branch'],
-            $actual['pattern'],
         )
     )
         ->toBe($expected);
@@ -15,87 +14,16 @@ it('verify correct domain generation for various branch formats', function ($act
     ->with([
         [
             'actual' => [
-                'branch' => 'user_notification+test',
-                'pattern' => null,
+                'branch' => 'user-notification-test',
                 'domain' => 'veyoze.com',
             ],
             'expected' => 'user-notification-test.veyoze.com',
         ],
         [
             'actual' => [
-                'branch' => 'feature/add-user-notification',
-                'pattern' => '/feature\/(.*)/i',
-                'domain' => 'veyoze.com',
-            ],
-            'expected' => 'add-user-notification.veyoze.com',
-        ],
-        [
-            'actual' => [
-                'branch' => 'feature/add-user-notification',
-                'pattern' => '/feature\/(.*)/i',
+                'branch' => 'user-notification',
                 'domain' => 'sub.veyoze.com',
             ],
-            'expected' => 'add-user-notification.sub.veyoze.com',
-        ],
-        [
-            'actual' => [
-                'branch' => 'feature/add@user-notification',
-                'pattern' => '/feature\/(.*)/i',
-                'domain' => 'veyoze.com',
-            ],
-            'expected' => 'add-user-notification.veyoze.com',
-        ],
-        [
-            'actual' => [
-                'branch' => 'feature/User-Notification',
-                'pattern' => '/feature\/(.*)/i',
-                'domain' => 'veyoze.com',
-            ],
-            'expected' => 'user-notification.veyoze.com',
-        ],
-        [
-            'actual' => [
-                'branch' => '360-add-user-notification',
-                'pattern' => '/\d+/i',
-                'domain' => 'veyoze.com',
-            ],
-            'expected' => '360.veyoze.com',
-        ],
-        [
-            'actual' => [
-                'branch' => 'vyz-145-add-user-notification',
-                'pattern' => '/vyz-\d+/i',
-                'domain' => 'veyoze.com',
-            ],
-            'expected' => 'vyz-145.veyoze.com',
-        ],
-        [
-            'actual' => [
-                'branch' => 'feature/user@notification!',
-                'pattern' => '/feature\/(.*)/i',
-                'domain' => 'veyoze.com',
-            ],
-            'expected' => 'user-notification.veyoze.com',
-        ],
-    ]);
-
-it('ensure graceful handling of invalid or problematic branch formats', function ($actual, $expected) {
-    expect(
-        GenerateDomainName::run(
-            $actual['domain'],
-            $actual['branch'],
-            $actual['pattern'],
-        )
-    )
-        ->toBe($expected);
-})
-    ->with([
-        [
-            'actual' => [
-                'branch' => 'feature/user-notification',
-                'pattern' => '/feature\/(.*)/i',
-                'domain' => 'veyoze',
-            ],
-            'expected' => 'user-notification.veyoze',
+            'expected' => 'user-notification.sub.veyoze.com',
         ],
     ]);

--- a/tests/Feature/OrCreateSiteTest.php
+++ b/tests/Feature/OrCreateSiteTest.php
@@ -11,6 +11,9 @@ test('it fails on incorrect payload', function ($site, $expectedErrors) {
     $service->shouldReceive('getFormattedDomainName')
         ->once()
         ->andReturn($site['name']);
+
+    $service->shouldReceive('getStandardizedBranchName')
+        ->once();
     $service->shouldReceive('createSite')
         ->once()
         ->andThrows(ValidationException::class, $expectedErrors);


### PR DESCRIPTION
Keep the site username (if isolated) the same as the filtered/generated domain name, for consistency.