### PR TITLE
Allow empty lines in env keys.

### DIFF
--- a/app/Actions/TextToArray.php
+++ b/app/Actions/TextToArray.php
@@ -37,7 +37,7 @@ class TextToArray
             $var = explode('=', $variable, 2);
 
             if (empty($var[0]) || empty($var[1])) {
-                return [];
+                continue;
             }
 
             $output[$var[0]] = $var[1];

--- a/app/Actions/TextToArray.php
+++ b/app/Actions/TextToArray.php
@@ -30,6 +30,10 @@ class TextToArray
 
         $output = [];
         foreach (explode($separator, $content) as $variable) {
+            if (empty($variable)) {
+                continue;
+            }
+
             $var = explode('=', $variable, 2);
 
             if (empty($var[0]) || empty($var[1])) {

--- a/tests/Feature/Actions/TextToArrayTest.php
+++ b/tests/Feature/Actions/TextToArrayTest.php
@@ -33,7 +33,10 @@ it('it converts key/value strings to array by semicolon and new-line', function 
             'actual' => [
                 'content' => "GOOGLE_API=MY_API_KEY\nINVALID_COMMENT INVALID_VALUE\nGITHUB_API=MY_SECOND_KEY",
             ],
-            'expected' => [],
+            'expected' => [
+                'GOOGLE_API' => 'MY_API_KEY',
+                'GITHUB_API' => 'MY_SECOND_KEY',
+            ],
         ],
         [
             'actual' => [
@@ -43,5 +46,11 @@ it('it converts key/value strings to array by semicolon and new-line', function 
                 'GOOGLE_API' => 'MY_API_KEY',
                 'GITHUB_API' => 'MY_SECOND_KEY'
             ],
+        ],
+        [
+            'actual' => [
+                'content' => "",
+            ],
+            'expected' => [],
         ],
     ]);

--- a/tests/Feature/Actions/TextToArrayTest.php
+++ b/tests/Feature/Actions/TextToArrayTest.php
@@ -35,4 +35,13 @@ it('it converts key/value strings to array by semicolon and new-line', function 
             ],
             'expected' => [],
         ],
+        [
+            'actual' => [
+                'content' => "GOOGLE_API=MY_API_KEY\n\nGITHUB_API=MY_SECOND_KEY",
+            ],
+            'expected' => [
+                'GOOGLE_API' => 'MY_API_KEY',
+                'GITHUB_API' => 'MY_SECOND_KEY'
+            ],
+        ],
     ]);


### PR DESCRIPTION
In a large application its visually useful to separate env variables into sections with empty lines e.g.

```
SERVICE_FOO_CLIENT_ID=123
SERVICE_FOO_SECRET_KEY=xy

SERVICE_BAR_ETC_ETC=987
```

but currently veyoze requires every line in the env file to contain a valid key/pair. Otherwise, no env keys are merged in at all (due to a return statement inside the parsing loop).

Becasue of this, it took me a while to figure out why my provisioned site contained no env keys.

This PR keeps existing behaviour of returning no env keys when an _invalid_ key/pair is found, but allows & ignores empty lines.